### PR TITLE
Making the package compatible with 3.6 by minor changes under the hood

### DIFF
--- a/pyreporter/utils.py
+++ b/pyreporter/utils.py
@@ -4,8 +4,9 @@ import numpy as np
 import pandas as pd
 import cobra
 import math
+from functools import reduce
 
-from typing import Tuple, List, Union
+from typing import Iterable, Tuple, List, Union
 
 
 
@@ -334,5 +335,8 @@ def geometric_mean(*numbers):
     if n == 0:
         raise ValueError('List of numbers is empty')
     numbers = [float(i) for i in numbers]
-    prod = math.prod(numbers)
+    prod = multiply(numbers)
     return prod ** (1 / n)
+
+def multiply(*numbers):
+    return np.prod(numbers)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -454,3 +454,23 @@ def test_geometric_mean_one():
     result = utils.geometric_mean(*nums)
     expected = 17.
     assert np.isclose(result, expected, rtol=R_TOLERANCE)
+
+def test_multiply_list():
+    testcase = [1, 2, 3, 4, 5]
+    result = utils.multiply(testcase)
+    expected = 1 * 2 * 3 * 4 * 5
+    print(result)
+    print(expected)
+    assert np.isclose(result, expected, rtol=R_TOLERANCE)
+
+def test_multiply_single():
+    testcase = 3
+    result = utils.multiply(testcase)
+    expected = 3
+    assert np.isclose(result, expected, rtol=R_TOLERANCE)
+
+def test_multiply_numbers():
+    testcase = [1, 2, 3, 4, 5]
+    result = utils.multiply(*testcase)
+    expected = 1 * 2 * 3 * 4 * 5
+    assert np.isclose(result, expected, rtol=R_TOLERANCE)


### PR DESCRIPTION
By replacing math.prod with numpy.prod we make the package 3.6 compatible.