### PR TITLE
Adding caching to pip, removing Python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.9", 
           "3.10",
           "3.11",
         ]
@@ -33,11 +32,12 @@ jobs:
           ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Seeing as how we recently triggered resource usage warnings, we're scaling down the pipeline a bit:
- use caching for pip packages
- take out the outdated Python 3.9 from tests