### PR TITLE
Prevent crash on failed GRP evaluation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gemcat"
-version = "1.4.0"
+version = "1.4.1"
 
 description = "A toolbox for gene expression-based prediction of metabolic alterations"
 keywords = ["python", "bioinformatics", "modeling", "metabolites", "omics"]

--- a/src/gemcat/expression.py
+++ b/src/gemcat/expression.py
@@ -229,7 +229,11 @@ class GeometricAndAverageMeans(ExpressionIntegration):
         """
         if len(gpr) == 0:
             return np.nan
-        result = parse_expr(gpr, {"geomean": geomean})
+        try:
+            result = parse_expr(gpr, {"geomean": geomean})
+        except SyntaxError:
+            logging.debug("Parsing failed for: %s", gpr)
+            return np.nan
         try:
             return float(result)
         except TypeError:


### PR DESCRIPTION
Currently, a failed GPR evaluation can crash the whole GEMCAT run.
Returning NaN for the crashing GPR and continuing execution is preferable.